### PR TITLE
set db to UTC, set event timestamps to store timezone

### DIFF
--- a/server/database/connection.js
+++ b/server/database/connection.js
@@ -21,8 +21,8 @@ const createTableQuery = `
     id SERIAL PRIMARY KEY,
     admin_id INT NOT NULL,
     name VARCHAR(255) NOT NULL,
-    event_start TIMESTAMP NOT NULL,
-    event_end TIMESTAMP NOT NULL,
+    event_start TIMESTAMP WITH TIME ZONE NOT NULL,
+    event_end TIMESTAMP WITH TIME ZONE NOT NULL,
     completed BOOLEAN NOT NULL,
     FOREIGN KEY (admin_id) REFERENCES admin(id)
   );
@@ -39,8 +39,8 @@ const createTableQuery = `
     id SERIAL PRIMARY KEY,
     teacher_id INT NOT NULL,
     name VARCHAR(255) NOT NULL,
-    event_start TIMESTAMP NOT NULL,
-    event_end TIMESTAMP NOT NULL,
+    event_start TIMESTAMP WITH TIME ZONE NOT NULL,
+    event_end TIMESTAMP WITH TIME ZONE NOT NULL,
     completed BOOLEAN NOT NULL,
     FOREIGN KEY (teacher_id) REFERENCES teachers(id)
   );
@@ -76,8 +76,8 @@ const createTableQuery = `
     id SERIAL PRIMARY KEY,
     student_id INT NOT NULL,
     name VARCHAR(255) NOT NULL,
-    event_start TIMESTAMP NOT NULL,
-    event_end TIMESTAMP NOT NULL,
+    event_start TIMESTAMP WITH TIME ZONE NOT NULL,
+    event_end TIMESTAMP WITH TIME ZONE NOT NULL,
     completed BOOLEAN NOT NULL,
     FOREIGN KEY (student_id) REFERENCES students(id)
   );
@@ -119,6 +119,9 @@ const createTableQuery = `
 `;
 
 client.connect()
+  .then(() => {
+    client.query("SET TIME ZONE 'UTC';");
+  })
   .then(() => {
     client.query('DROP TABLE IF EXISTS roles, admin, admin_calendar, teachers, teachers_emails, teachers_calendar, classes, assignments, teachers_assignments, students, students_emails, students_calendar, students_assignments, classes_students, credentials, admin_credentials, teachers_credentials, students_credentials CASCADE;');
   })


### PR DESCRIPTION
Attempting to address time discrepancy in deployed version (which is not present locally)

Added client query to set db session to UTC - this will convert any timestamps with timezones to UTC for consistency

Set event timestamp properties to TIMESTAMP WITH TIME ZONE NOT NULL to store  their timestamps. Calendar components convert to local time with a localizer.